### PR TITLE
Allow FastCGI to use more buffer

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -14,6 +14,15 @@ server {
   client_max_body_size 20m;
   client_body_timeout 90s;
 
+  # https://stackoverflow.com/a/25762701
+  fastcgi_buffers  16 16k;
+  fastcgi_buffer_size  32k;
+
+  # https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
+  proxy_buffer_size 16k;
+  proxy_busy_buffers_size 24k;
+  proxy_buffers 64 4k;
+
   sendfile on;
 
   location / {
@@ -23,28 +32,28 @@ server {
   location ~ \.php$ {
     root /var/www/html/web;
 
-		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
     # ECS in awsvpc network mode makes the FPM task accessible on (only) a local IP.
-		fastcgi_pass   127.0.0.1:9000;
-		fastcgi_index  index.php;
+    fastcgi_pass   127.0.0.1:9000;
+    fastcgi_index  index.php;
 
-		include fastcgi_params;
+    include fastcgi_params;
 
-		# Mitigate https://httpoxy.org/ vulnerabilities
-		fastcgi_param HTTP_PROXY "";
-		fastcgi_intercept_errors off;
-		fastcgi_connect_timeout 30s;
-		fastcgi_send_timeout 300s;
-		fastcgi_read_timeout 600s;
+    # Mitigate https://httpoxy.org/ vulnerabilities
+    fastcgi_param HTTP_PROXY "";
+    fastcgi_intercept_errors off;
+    fastcgi_connect_timeout 30s;
+    fastcgi_send_timeout 300s;
+    fastcgi_read_timeout 600s;
 
-		# Removing the leading slash from $fastcgi_script_name allows it to be interpreted relative to php-fpm.conf's `chdir` directive
-		set $filename "index.php";
-		if ( $fastcgi_script_name ~ "^/+(.*)$" ) {
-			set $filename $1;
-		}
-		fastcgi_param SCRIPT_FILENAME $filename;
-		fastcgi_param PATH_INFO       $fastcgi_path_info;
-		fastcgi_param PATH_TRANSLATED $fastcgi_path_info;
-	}
+    # Removing the leading slash from $fastcgi_script_name allows it to be interpreted relative to php-fpm.conf's `chdir` directive
+    set $filename "index.php";
+    if ( $fastcgi_script_name ~ "^/+(.*)$" ) {
+    	set $filename $1;
+    }
+    fastcgi_param SCRIPT_FILENAME $filename;
+    fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_param PATH_TRANSLATED $fastcgi_path_info;
+  }
 }


### PR DESCRIPTION
Reduce the chance of e.g. 502s from a lot of PHP warnings